### PR TITLE
Pagination for getting members using Bot API

### DIFF
--- a/Microsoft.Teams.Apps.Scrum/Bots/ScrumBot.cs
+++ b/Microsoft.Teams.Apps.Scrum/Bots/ScrumBot.cs
@@ -50,11 +50,6 @@ namespace Microsoft.Teams.Apps.Scrum.Bots
         private readonly IScrumProvider scrumProvider;
         private readonly TelemetryClient telemetryClient;
 
-        ///// <summary>
-        ///// Sends logs to the Application Insights service.
-        ///// </summary>
-        // private readonly ILogger logger;
-
         /// <summary>
         /// Cache for storing authorization result.
         /// </summary>
@@ -467,9 +462,12 @@ namespace Microsoft.Teams.Apps.Scrum.Bots
             string continuationToken = null;
             do
             {
-                var currentPage = await TeamsInfo.GetPagedMembersAsync(turnContext, pageSize: 500, continuationToken, cancellationToken);
-                continuationToken = currentPage.ContinuationToken;
-                members.AddRange(currentPage.Members);
+                await memberRetryPolicy.ExecuteAsync(async () =>
+                {
+                    var currentPage = await TeamsInfo.GetPagedMembersAsync(turnContext, pageSize: 500, continuationToken, cancellationToken);
+                    continuationToken = currentPage.ContinuationToken;
+                    members.AddRange(currentPage.Members);
+                });
             }
             while (continuationToken != null);
             return members;

--- a/Microsoft.Teams.Apps.Scrum/Bots/ScrumBot.cs
+++ b/Microsoft.Teams.Apps.Scrum/Bots/ScrumBot.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Teams.Apps.Scrum.Bots
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.ApplicationInsights;
@@ -15,6 +16,7 @@ namespace Microsoft.Teams.Apps.Scrum.Bots
     using Microsoft.Bot.Builder.Teams;
     using Microsoft.Bot.Schema;
     using Microsoft.Bot.Schema.Teams;
+    using Microsoft.Extensions.Caching.Memory;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Rest;
     using Microsoft.Teams.Apps.Scrum.Cards;
@@ -32,13 +34,31 @@ namespace Microsoft.Teams.Apps.Scrum.Bots
     /// </summary>
     public class ScrumBot : TeamsActivityHandler
     {
+        /// <summary>
+        /// Sets the team members cache key.
+        /// </summary>
+        private const string TeamMembersCacheKey = "teamMembersCacheKey";
+
         private static AsyncRetryPolicy retryPolicy = Policy.Handle<HttpOperationException>()
+            .WaitAndRetryAsync(Backoff.DecorrelatedJitterBackoffV2(TimeSpan.FromMilliseconds(1000), 5));
+
+        private static AsyncRetryPolicy memberRetryPolicy = Policy.Handle<HttpOperationException>(ex => ex.Response.StatusCode == HttpStatusCode.TooManyRequests)
             .WaitAndRetryAsync(Backoff.DecorrelatedJitterBackoffV2(TimeSpan.FromMilliseconds(1000), 5));
 
         private readonly string expectedTenantId;
         private readonly IConfiguration configuration;
         private readonly IScrumProvider scrumProvider;
         private readonly TelemetryClient telemetryClient;
+
+        ///// <summary>
+        ///// Sends logs to the Application Insights service.
+        ///// </summary>
+        // private readonly ILogger logger;
+
+        /// <summary>
+        /// Cache for storing authorization result.
+        /// </summary>
+        private readonly IMemoryCache memoryCache;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ScrumBot"/> class.
@@ -47,12 +67,15 @@ namespace Microsoft.Teams.Apps.Scrum.Bots
         /// <param name="configuration">Configuration.</param>
         /// <param name="scrumProvider">scrumProvider.</param>
         /// <param name="telemetryClient">Telemetry.</param>
-        public ScrumBot(IConfiguration configuration, IScrumProvider scrumProvider, TelemetryClient telemetryClient)
+        /// <param name="logger">Instance to send logs to the Application Insights service.</param>
+        /// <param name="memoryCache">MemoryCache instance for caching authorization result.</param>
+        public ScrumBot(IConfiguration configuration, IScrumProvider scrumProvider, TelemetryClient telemetryClient, IMemoryCache memoryCache)
         {
             this.scrumProvider = scrumProvider;
             this.telemetryClient = telemetryClient;
             this.configuration = configuration;
             this.expectedTenantId = configuration["TenantId"];
+            this.memoryCache = memoryCache;
         }
 
         /// <inheritdoc/>
@@ -427,9 +450,29 @@ namespace Microsoft.Teams.Apps.Scrum.Bots
         /// <returns>true if members are more than allowed limit.</returns>
         private async Task<bool> IsMemberCountGreaterThanAllowed(ITurnContext turnContext, CancellationToken cancellationToken)
         {
-            var members = await TeamsInfo.GetMembersAsync(turnContext, cancellationToken);
-            this.telemetryClient.TrackTrace($"Total Members in group chat is :{members.Count()}");
+            bool isCacheEntryExists = this.memoryCache.TryGetValue(TeamMembersCacheKey, out List<TeamsChannelAccount> members);
+            if (!isCacheEntryExists)
+            {
+                members = await this.GetTeamMembersAsync(turnContext, cancellationToken);
+                this.memoryCache.Set(TeamMembersCacheKey, members, TimeSpan.FromDays(3));
+                this.telemetryClient.TrackTrace($"Total Members in group chat is :{members.Count()}");
+            }
+
             return members.Count() > Constants.MaxAllowedMembers;
+        }
+
+        private async Task<List<TeamsChannelAccount>> GetTeamMembersAsync(ITurnContext turnContext, CancellationToken cancellationToken)
+        {
+            List<TeamsChannelAccount> members = new List<TeamsChannelAccount>();
+            string continuationToken = null;
+            do
+            {
+                var currentPage = await TeamsInfo.GetPagedMembersAsync(turnContext, pageSize: 500, continuationToken, cancellationToken);
+                continuationToken = currentPage.ContinuationToken;
+                members.AddRange(currentPage.Members);
+            }
+            while (continuationToken != null);
+            return members;
         }
 
         /// <summary>
@@ -477,7 +520,13 @@ namespace Microsoft.Teams.Apps.Scrum.Bots
         private async Task<Dictionary<string, string>> GetActivityIdOfMembersInScrum(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
         {
             var membersActivityIdMap = new Dictionary<string, string>();
-            var members = await TeamsInfo.GetMembersAsync(turnContext, cancellationToken);
+            bool isCacheEntryExists = this.memoryCache.TryGetValue(TeamMembersCacheKey, out List<TeamsChannelAccount> members);
+            if (!isCacheEntryExists)
+            {
+                members = await this.GetTeamMembersAsync(turnContext, cancellationToken);
+                this.memoryCache.Set(TeamMembersCacheKey, members, TimeSpan.FromDays(1));
+                this.telemetryClient.TrackTrace($"Total Members in group chat is :{members.Count()}");
+            }
 
             foreach (var member in members)
             {

--- a/Microsoft.Teams.Apps.Scrum/Bots/ScrumBot.cs
+++ b/Microsoft.Teams.Apps.Scrum/Bots/ScrumBot.cs
@@ -531,11 +531,11 @@ namespace Microsoft.Teams.Apps.Scrum.Bots
                 var mentionActivity = MessageFactory.Attachment(ScrumStartCards.GetNameCard(member.Name));
                 mentionActivity.Entities = new List<Entity>();
                 var mentionedEntity = member;
-                string mentionEntityText = string.Format("<at>{0}</at>", mentionedEntity.Name);
+                string mentionEntityText = string.Format("{0}", mentionedEntity.Name);
 
                 mentionActivity.Entities.Add(new Mention
                 {
-                    Text = mentionEntityText,
+                    Text = WebUtility.HtmlEncode(mentionEntityText),
                     Mentioned = mentionedEntity,
                 });
 

--- a/Microsoft.Teams.Apps.Scrum/Microsoft.Teams.Apps.Scrum.csproj
+++ b/Microsoft.Teams.Apps.Scrum/Microsoft.Teams.Apps.Scrum.csproj
@@ -70,7 +70,7 @@
     <PackageReference Include="AdaptiveCards" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.6" />
     <PackageReference Include="Microsoft.AspNetCore.All" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.6.3" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.12.2" />
     <PackageReference Include="Microsoft.Bot.Connector.Teams" Version="0.9.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.9" />

--- a/Microsoft.Teams.Apps.Scrum/Startup.cs
+++ b/Microsoft.Teams.Apps.Scrum/Startup.cs
@@ -68,6 +68,8 @@ namespace Microsoft.Teams.Apps.Scrum
             services.AddScoped<IBot, ScrumBot>();
 
             services.AddSingleton(new TelemetryClient(new TelemetryConfiguration(this.Configuration["APPINSIGHTS_INSTRUMENTATIONKEY"])));
+
+            services.AddMemoryCache();
         }
 
         /// <summary>


### PR DESCRIPTION
**Issue details** - TeamsInfo.GetTeamMembersAsync method to retrieve information for one or more members of a chat or team has been deprecated.

**Solution details** - used TeamsInfo.GetPagedMembersAsync instead of TeamsInfo.GetTeamMembersAsync.
Implemented caching to store team member details.
Updated Microsoft.Bot.Builder.Integration.AspNet.Core version to 4.12.2
Note - The limit of team members is 20.

**Testing done** -
Tested caching by adding 10 members to the Scrum group.